### PR TITLE
add osRun template function and change template Delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,4 @@
-```
-   :::     :::  ::::::::  ::::::::: ::::::::::: :::::::::: :::    :::
-  :+:     :+: :+:    :+: :+:    :+:    :+:     :+:        :+:    :+:  
- +:+     +:+ +:+    +:+ +:+    +:+    +:+     +:+         +:+  +:+    
-+#+     +:+ +#+    +:+ +#++:++#:     +#+     +#++:++#     +#++:+      
-+#+   +#+  +#+    +#+ +#+    +#+    +#+     +#+         +#+  +#+      
-#+#+#+#   #+#    #+# #+#    #+#    #+#     #+#        #+#    #+#      
- ###      ########  ###    ###    ###     ########## ###    ###       
-```
-
----
-
-[![Build Status](https://travis-ci.org/AlexsJones/vortex.svg?branch=master)](https://travis-ci.org/AlexsJones/vortex)
-[![Maintainability](https://api.codeclimate.com/v1/badges/93b3be49a1b077adc0ba/maintainability)](https://codeclimate.com/github/AlexsJones/vortex/maintainability)
+This project is forked from github.com/AlexsJones/vortex
 
 A simple template reader and variable injector
 
@@ -21,7 +8,7 @@ A simple template reader and variable injector
 
 ## Install
 
-`go get github.com/AlexsJones/vortex`
+`go get github.com/codelity/vortex`
 
 _Or navigate to the releases page and install as a binary on the path_
 
@@ -42,8 +29,8 @@ metadata:
 spec:
   restartPolicy: Always
   containers:
-    - name: {{.name}}
-      image: {{.image}}
+    - name: {{{.name}}}
+      image: {{{.image}}}
 
 ```
 
@@ -100,34 +87,34 @@ The perfect Kubernetes companion...
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{.info.namespace}}-ingress
-  namespace: {{.info.namespace}}
+  name: {{{.info.namespace}}}-ingress
+  namespace: {{{.info.namespace}}}
   annotations:
     kubernetes.io/ingress.class: "nginx"
     kubernetes.io/ingress.allow-http: "false"
 spec:
   tls:
-  {{ range .ingress }}
+  {{{ range .ingress }}}
   - hosts:
-    - {{.ing.hostname}}
-    secretName: {{.ing.tlssecretname}}
-  {{end}}
+    - {{{.ing.hostname}}}
+    secretName: {{{.ing.tlssecretname}}}
+  {{{end}}}
   rules:
-  {{ range .ingress }}
-  - host: {{.ing.hostname}}
+  {{{ range .ingress }}}
+  - host: {{{.ing.hostname}}}
     http:
       paths:
       - backend:
-          serviceName: {{.ing.servicename}}
-          servicePort: {{.ing.serviceport}}
-  {{end}}
+          serviceName: {{{.ing.servicename}}}
+          servicePort: {{{.ing.serviceport}}}
+  {{{end}}}
 
  ```
  ```
  apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kubernetes-{{.info.environment}}-service-account
+  name: kubernetes-{{{.info.environment}}}-service-account
   namespace: frontier
 
 ---
@@ -135,10 +122,10 @@ metadata:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: kubernetes-{{.info.environment}}-service-account-binding
+  name: kubernetes-{{{.info.environment}}}-service-account-binding
 subjects:
   - kind: ServiceAccount
-    name: kubernetes-{{.info.environment}}-service-account
+    name: kubernetes-{{{.info.environment}}}-service-account
     namespace: frontier
 roleRef:
   kind: ClusterRole
@@ -150,7 +137,7 @@ roleRef:
 
 ```
 env:
-    API_KEY: {{ vaultsecret "/secret/path/to/secret" "keyInDataMap" }}
+    API_KEY: {{{ vaultsecret "/secret/path/to/secret" "keyInDataMap" }}}
 ```
 
 For this to work, you will need to have:
@@ -161,8 +148,8 @@ Using environment variables inside your templates:
 
 ```
 annotations:
-  UpdatedBy: {{ getenv "USER" }}
-  SecretUsed: {{ getenv "SECRET_TOKEN" }}
+  UpdatedBy: {{{ getenv "USER" }}}
+  SecretUsed: {{{ getenv "SECRET_TOKEN" }}}
 ```
 
 This enables secrets to be loaded via environment variables rather than alternative methods such as using `sed` over
@@ -176,7 +163,3 @@ go mod vendor
 docker build .
 ```
 
-
-#### Run from a docker image
-
- `docker run -v /Users/alex/Work/vortex-test:/tmp vortex:v1 -template /tmp/demo.yaml -output /tmp/deployment -varpath /tmp/vars.vortex`

--- a/example/.mistyped/template.yaml
+++ b/example/.mistyped/template.yaml
@@ -5,4 +5,4 @@
 Key : Type
 Hello: |
   Nice to meet you sonny
-Context; {{ .Image }}
+Context; {{{ .Image }}}

--- a/example/bar/example.yaml
+++ b/example/bar/example.yaml
@@ -1,8 +1,8 @@
 ---
-Image: {{ .image }}
+Image: {{{ .image }}}
 
 items:
-    - {{ .image }}
-    - {{ .image }}
-    - {{ .image }}
-HomeDir: {{ getenv "HOME" }}
+    - {{{ .image }}}
+    - {{{ .image }}}
+    - {{{ .image }}}
+HomeDir: {{{ getenv "HOME" }}}

--- a/example/demo.yaml
+++ b/example/demo.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   restartPolicy: Always
   containers:
-    - name: {{.api.name}}
-      image: {{.api.image}}
+    - name: {{{.api.name}}}
+      image: {{{.api.image}}}
   someaddresses:
-    {{range .api.ipaddressrange}}
-    - ip: {{.}}{{end}}
+    {{{range .api.ipaddressrange}}}
+    - ip: {{{.}}}{{{end}}}

--- a/go.mod
+++ b/go.mod
@@ -26,3 +26,5 @@ require (
 	gopkg.in/fsnotify/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+go 1.12

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -158,13 +158,14 @@ func (v *vortex) processTemplate(templatepath, outputpath string) error {
 	if err != nil {
 		return err
 	}
-	tmpl, err := template.New(path.Base(templatepath)).
+	tmpl, err := template.New(path.Base(templatepath)).Delims("{{{", "}}}").
 		Funcs(template.FuncMap{
-			"vaultsecret": secrets.VaultFetchSecret,
-			"getenv":      os.Getenv,
-			"md5":         hashMd5,
+			"vaultsecret":  secrets.VaultFetchSecret,
+			"getenv":       os.Getenv,
+			"md5":          hashMd5,
 			"base64Encode": base64Encode,
 			"base64Decode": base64Decode,
+			"osRun":        osRun,
 		}).
 		Parse(string(buff))
 	if err != nil {

--- a/processor/template_functions.go
+++ b/processor/template_functions.go
@@ -6,6 +6,8 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"os/exec"
+	"strings"
 )
 
 func hashMd5(text ...string) (string, error) {
@@ -15,7 +17,6 @@ func hashMd5(text ...string) (string, error) {
 	}
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }
-
 
 func base64Decode(text ...string) (string, error) {
 	buff := bytes.NewBuffer(nil)
@@ -39,4 +40,13 @@ func base64Encode(text ...string) (string, error) {
 		}
 	}
 	return base64.StdEncoding.EncodeToString(buff.Bytes()), nil
+}
+
+func osRun(app string, arg ...string) (string, error) {
+	cmd := exec.Command(app, arg...)
+	stdout, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(string(stdout), "\n"), nil
 }


### PR DESCRIPTION
Changes:
- Replace template delimiter from '{{' and '}}' to '{{{' and '}}}' to solve Grafana dashboard conflicts
New Features:
- add osRun template function to get os setting from runtime